### PR TITLE
fix: #7 reorder conditions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-        "default": "./lib/index.js",
-        "types": "./lib/index.d.ts"
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Bundling with SWC fails on this package.
As stated [here](https://nodejs.org/api/packages.html#conditional-exports):

> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.

Resolves #7 